### PR TITLE
Porting "setup" for lavender

### DIFF
--- a/devices/lavender/disable_encryption.sh
+++ b/devices/lavender/disable_encryption.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-DEVICE=angler
+# lavender has fstab.qcom instead of fstab.lavender, so keeping this
+# variable qcom.
+DEVICE=qcom
 
 tools=(
 abootimg
@@ -21,7 +23,9 @@ check_perm() {
 }
 show_warning() {
     delay=10
-    warn "This script is for device $DEVICE.  Using this script"
+    # changing the script a bit just so that variables are not incorrectly used. 
+    # s/device $DEVICE/lavender/
+    warn "This script is for lavender.  Using this script"
     warn "on other devices may fail or cause damage to your device."
     warn "This script will wipe all user data on your device."
     warn "Make sure you backup important data on the device before"
@@ -70,7 +74,7 @@ info "Unpacked initramfs"
 # ============================================================
 # Device-specific logic -- change forcefdeorfbe to encryptable
 # ============================================================
-sed -i -e 's/forcefdeorfbe/encryptable/g' rootfs/fstab.$DEVICE || die "Failed to modify fstab.$DEVICE to disable encryption"
+sed -i -e 's/forceencrypt/encryptable/g' rootfs/fstab.$DEVICE || die "Failed to modify fstab.$DEVICE to disable encryption"
 info "Modified fstab.$DEVICE to disable encryption"
 # ============================================================
 # End of device-specific logic

--- a/devices/lavender/disable_encryption.sh
+++ b/devices/lavender/disable_encryption.sh
@@ -72,7 +72,7 @@ cat initrd.img | gunzip | cpio -vidD rootfs || die "Failed to unpack initrd"
 info "Unpacked initramfs"
 
 # ============================================================
-# Device-specific logic -- change forcefdeorfbe to encryptable
+# Device-specific logic -- change forceencrypt to encryptable
 # ============================================================
 sed -i -e 's/forceencrypt/encryptable/g' rootfs/fstab.$DEVICE || die "Failed to modify fstab.$DEVICE to disable encryption"
 info "Modified fstab.$DEVICE to disable encryption"

--- a/devices/lavender/disable_encryption.sh
+++ b/devices/lavender/disable_encryption.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+DEVICE=angler
+
+tools=(
+abootimg
+adb
+cpio
+fastboot
+gunzip
+gzip
+)
+
+detect_tools() {
+    for a in ${tools[@]}; do
+        which $a >/dev/null 2>&1 || die "Required tool $a not found in PATH"
+    done
+}
+check_perm() {
+    [ "$(whoami)" = "root" ] || die "This script must be ran as root"
+}
+show_warning() {
+    delay=10
+    warn "This script is for device $DEVICE.  Using this script"
+    warn "on other devices may fail or cause damage to your device."
+    warn "This script will wipe all user data on your device."
+    warn "Make sure you backup important data on the device before"
+    warn "continuing."
+    warn "Waiting $delay seconds before continuing..."
+    sleep $delay
+}
+clean() {
+    rm -rf $tmpdir >/dev/null 2>&1 || true
+}
+info() {
+    echo "[INFO] $@" 
+}
+warn() {
+    echo "[WARN] $@" >&2
+}
+die() {
+    echo "[ERR ] $@" >&2
+    clean && exit 1
+}
+
+check_perm
+detect_tools
+show_warning
+tmpdir=/tmp/disable-encryption_$(uuidgen)
+mkdir -p $tmpdir || die "Failed to create temp dir $tmpdir"
+
+bootblk=/dev/block/bootdevice/by-name/boot
+bootimg=$tmpdir/boot.img
+newbootimg=$tmpdir/new.img
+
+adb devices | grep "device$" || \
+    die "Device not found or unauthorized.  Fix adb access and try again."
+info "Found device"
+adb root || die "Failed to restart adbd as root"
+sleep 2
+
+cd $tmpdir
+adb pull $bootblk $bootimg || die "Failed to pull boot.img from device"
+info "Pulled boot.img from device"
+abootimg -x $bootimg || die "Failed to unpack boot.img"
+mkdir rootfs
+cat initrd.img | gunzip | cpio -vidD rootfs || die "Failed to unpack initrd"
+info "Unpacked initramfs"
+
+# ============================================================
+# Device-specific logic -- change forcefdeorfbe to encryptable
+# ============================================================
+sed -i -e 's/forcefdeorfbe/encryptable/g' rootfs/fstab.$DEVICE || die "Failed to modify fstab.$DEVICE to disable encryption"
+info "Modified fstab.$DEVICE to disable encryption"
+# ============================================================
+# End of device-specific logic
+# ============================================================
+
+pushd rootfs >/dev/null
+find . | cpio --create --format='newc' | gzip > ../initrd.img || die "Failed to create new initrd"
+popd >/dev/null
+sed -i bootimg.cfg \
+    -e '/bootsize/d' \
+    -e 's/enforcing/permissive/g' \
+    -e 's/\(cmdline.=.\)/\1androidboot.selinux=permissive /g' \
+    || die "Failed to modify bootimg.cfg to remove size limit"
+abootimg --create $newbootimg -f bootimg.cfg -k zImage -r initrd.img || die "Failed to create new boot.img"
+info "Created new boot.img"
+
+adb reboot bootloader || die "Failed to reboot phone"
+
+info "Waiting 10 seconds for device to show up in fastboot mode..."
+sleep 10
+fastboot flash boot $newbootimg || die "Failed to flash new boot.img"
+info "Flashed new boot.img"
+fastboot format userdata || die "Failed to format userdata"
+info "Erased userdata"
+fastboot format cache || die "Failed to format cache"
+info "Erased cache"
+fastboot reboot || die "Failed to reboot phone"
+info "Rebooting phone..."
+
+info "All done! Check mount information to see if encryption has been disabled."
+
+clean && exit 0

--- a/devices/lavender/fstab.android
+++ b/devices/lavender/fstab.android
@@ -1,0 +1,14 @@
+# Android mounts
+/dev/block/mmcblk0p43 /var/lib/android/system ext4 ro,barrier=1,inode_readahead_blks=8 0 0
+/dev/block/mmcblk0p55 /var/lib/android/persist ext4 noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit 0 0
+/dev/block/mmcblk0p64 /var/lib/android/vendor ext4 ro,barrier=1,inode_readahead_blks=8 0 0
+/dev/block/mmcblk0p62 /var/lib/android/cache ext4 noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc 0 0
+/dev/block/mmcblk0p66 /var/lib/android/data ext4 noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,inode_readahead_blks=8 0 0
+
+# Bind into container
+/var/lib/android/system /var/lib/lxc/android/rootfs/system none bind 0 0
+/var/lib/android/persist /var/lib/lxc/android/rootfs/persist none bind 0 0
+/var/lib/android/vendor /var/lib/lxc/android/rootfs/vendor none bind 0 0
+/var/lib/android/cache /var/lib/lxc/android/rootfs/cache none bind 0 0
+/var/lib/android/data /var/lib/lxc/android/rootfs/data none bind 0 0
+/run /var/lib/lxc/android/rootfs/run none bind 0 0

--- a/devices/lavender/patches/fstab.qcom.patch
+++ b/devices/lavender/patches/fstab.qcom.patch
@@ -1,0 +1,24 @@
+diff --git a/fstab.qcom b/fstab.qcom
+index 306e8fc..e0dda94 100644
+--- a/fstab.qcom
++++ b/fstab.qcom
+@@ -9,14 +9,14 @@
+ #<src>                                   <mnt_point>            <type> <mnt_flags and options>                          <fs_mgr_flags>
+ /dev/block/bootdevice/by-name/boot           /boot              emmc    defaults                                   recoveryonly
+ /dev/block/bootdevice/by-name/recovery       /recovery          emmc    defaults                                   recoveryonly
+-/dev/block/bootdevice/by-name/vendor         /vendor            ext4    ro,barrier=1                               wait,recoveryonly
+-/dev/block/bootdevice/by-name/system     /                      ext4   ro,barrier=1,discard                             wait,avb
+-/dev/block/bootdevice/by-name/userdata   /data                  ext4   nosuid,nodev,barrier=1,noauto_da_alloc,noatime,lazytime   wait,check,forceencrypt=footer,quota,reservedsize=128M
++#/dev/block/bootdevice/by-name/vendor         /vendor            ext4    ro,barrier=1                               wait,recoveryonly
++#/dev/block/bootdevice/by-name/system     /                      ext4   ro,barrier=1,discard                             wait,avb
++#/dev/block/bootdevice/by-name/userdata   /data                  ext4   nosuid,nodev,barrier=1,noauto_da_alloc,noatime,lazytime   wait,check,forceencrypt=footer,quota,reservedsize=128M
+ /devices/soc/c084000.sdhci/mmc_host*     /storage/sdcard1       vfat   nosuid,nodev                                     wait,voldmanaged=sdcard1:auto,encryptable=footer
+ /dev/block/bootdevice/by-name/misc       /misc                  emmc   defaults                                         defaults
+ /dev/block/bootdevice/by-name/modem      /vendor/firmware_mnt   vfat   ro,shortname=lower,uid=0,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait
+ /dev/block/bootdevice/by-name/bluetooth  /vendor/bt_firmware    vfat   ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:bt_firmware_file:s0 wait
+ /devices/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto*     /storage/usbotg    vfat    nosuid,nodev         wait,voldmanaged=usbotg:auto
+ /dev/block/bootdevice/by-name/dsp        /vendor/dsp            ext4   ro,nosuid,nodev,barrier=1                        wait
+-/dev/block/bootdevice/by-name/cache      /cache                 ext4   nosuid,nodev,noatime,barrier=1                           wait
+-/dev/block/bootdevice/by-name/persist    /mnt/vendor/persist    ext4   noatime,nosuid,nodev,barrier=1                   wait,check
++#/dev/block/bootdevice/by-name/cache      /cache                 ext4   nosuid,nodev,noatime,barrier=1                           wait
++#/dev/block/bootdevice/by-name/persist    /mnt/vendor/persist    ext4   noatime,nosuid,nodev,barrier=1                   wait,check

--- a/devices/lavender/patches/init.rc.patch
+++ b/devices/lavender/patches/init.rc.patch
@@ -1,0 +1,54 @@
+diff --git a/init.rc b/init.rc
+index 4a8a60a..283a3bb 100644
+--- a/init.rc
++++ b/init.rc
+@@ -26,6 +26,8 @@ on early-init
+ 
+     # Mount cgroup mount point for cpu accounting
+     mount cgroup none /acct nodev noexec nosuid cpuacct
++    # use container's cpuacct pseudo-fs instead of host's
++    mount none /acct/lxc/android /acct/bind
+     mkdir /acct/uid
+ 
+     # root memory control cgroup, used by lmkd
+@@ -151,6 +153,8 @@ on init
+     # Create cgroup mount points for process groups
+     mkdir /dev/cpuctl
+     mount cgroup none /dev/cpuctl nodev noexec nosuid cpu
++    #use container's cpuctl pseudo-fs instead of host's
++    mount none /dev/cpuctl/lxc/android /dev/cpuctl bind
+     chown system system /dev/cpuctl
+     chown system system /dev/cpuctl/tasks
+     chmod 0666 /dev/cpuctl/tasks
+@@ -160,6 +164,8 @@ on init
+     # sets up initial cpusets for ActivityManager
+     mkdir /dev/cpuset
+     mount cpuset none /dev/cpuset nodev noexec nosuid
++    # use container's cpuset pseudo-fs instead of host's
++    mount none /dev/cpuset/lxc/android /dev/cpuset/bind
+ 
+     # this ensures that the cpusets are present and usable, but the device's
+     # init.rc must actually set the correct cpus
+@@ -742,14 +748,14 @@ service ueventd /sbin/ueventd
+     seclabel u:r:ueventd:s0
+     shutdown critical
+ 
+-service console /system/bin/sh
+-    class core
+-    console
+-    disabled
+-    user shell
+-    group shell log readproc
+-    seclabel u:r:shell:s0
+-    setenv HOSTNAME console
++#service console /system/bin/sh
++#    class core
++#    console
++#    disabled
++#    user shell
++#    group shell log readproc
++#    seclabel u:r:shell:s0
++#    setenv HOSTNAME console
+ 
+ on property:ro.debuggable=1
+     # Give writes to anyone for the trace folder on debug builds.

--- a/devices/lavender/serial-consoles
+++ b/devices/lavender/serial-consoles
@@ -1,0 +1,1 @@
+s0:12345:respawn:/sbin/agetty -L 115200 ttyMSM0 vt100


### PR DESCRIPTION
Please have a look at the changes, whether they are correct.
Some pointers before you inspect :

- My device (lavender) shipped with android 9+ and so the contents of the `ramdisk` have all been shifted into the `system.img`. The reason for this is because my device is SAR ( system-as-root). [relevant source](https://source.android.com/devices/bootloader/system-as-root). Please let me know if my PR needs any adaption in accordance with the upcoming of SAR.
- I do not know why and when this happened, but my device has `fstab.qcom` instead of `fstab.lavender`. I have submitted patches for the same. Please let me know if I am submitting the patches for the correct file.
- The changes I made in `disable_encryption.sh`, very specifically the line `s/forceencrypt/encryptable/` ; I changed `forcefdeorfbe` to `encryptable` because the option I had in my `fstab.qcom` for `data` partition was `encryptable` instead of `forcefdeorfbe`. Please let me know whether this needs correction. [relevant source](https://source.android.com/security/encryption/full-disk.html).

Thanks a ton for putting effort in this project. I would love to be a part of it and try it.